### PR TITLE
Update Idlib

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,2 @@
 Current Developers:
-	Michael Heilmann           <michaelheilmann@primordialmachine.com>
+    Michael Heilmann           <michaelheilmann@primordialmachine.com>

--- a/COPYING
+++ b/COPYING
@@ -1,2 +1,1 @@
-IdLib is made available publicly under the GNU GPLv3 License.
-See README.md in this directory for more information.
+See LICENSE in this directory.

--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,21 @@
-  Copyright (C) 2015-2018 Michael Heilmann
+MIT License
 
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
+Copyright (c) 2018 Michael Heilmann
 
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,56 @@
 # Idlib
 
 Idlib is a C++17 cross-platform utility library for Windows, Linux, and OS X.
-Idlib and is made available publicly under the [Idlib license](https://primordialmachine.com/license) on [Github](https://github.com/primordialmachine/idlib).
-Visit the the
-[Idlib project page](https://primordialmachine.com/idlib)
-or the
+Idlib and is made available publicly under the
+[MIT license](https://github.com/primordialmachine/idlib/blob/master/LICENSE.md)
+on
+[Github](https://github.com/primordialmachine/idlib).
+
+The library was built and used under Windows/Visual Studio 2017, Linux/GCC 6, Linux/Clang, and OS X/Clang.
+
+Visit the
 [![Idlib Gitter channel](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/primordialmachine/primordialmachine?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 for more information.
+
+### Featurette
+
+* CMake-based build system
+   builds under Windows/Visual Studio, Cygwin/GCC, Linux/GCC and OS X/Clang
+* Google Test integration for Visual Studio
+* math
+	* generic vectors of arbitrary dimensions for all floating-point types
+	* generic matrices of arbitrary number of rows and columns for all floating-point types
+	* generic geometric primitives (points, lines, rays, aabbs, …) of arbitrary dimensions for all floating-point types
+	* translation transformations of geometric primitives
+	* coming soon:
+		* full support for all standard transformations (scale, shear, rotation, …)
+		* viewing and projection transformations (“look at”, “perspective projection”, orthographic projection”)
+	* colors RGB and RGBA colors for all floating-point types and for Bytes
+	* file system abstraction on Windows,  Linux, OS X
+	* reading and writing files using memory mappings
+	* creating/copying/deleting files and directories
+	* enumerating directory contents
+	* obtaining file system information (e.g. application data directories)
+* Byte-order detection and conversion
+* parsing template-metafunction parser-builder for Parsing Expression Grammars
+* signals and slots type-safe signals-slots
+* misc. C++ utilities
+	* transform iterators
+	* singletons with sub-typing
+	* iterator ranges
+	* sub-range values
+	* …
+
+### Build instructions
+
+Download or checkout the source code from https://primordialmachine.com/idlib/.
+See below for build instructions for some of the individual environments.
+
+* [Windows 10/Visual Studio Community 2017](documentation/building-under-windows-10-visual-studio-community-2017.md)
+* [Windows 10/Cygwin](documentation/building-under-windows-10-cygwin.md)
+* [Linux/GCC](documentation/building-under-linux-gcc.md)
+* [Linux/Clang](documentation/building-under-linux-clang.md)
+* [OS X/Clang](documentation/building-under-os-x-clang.md)
 
 ### Continuous Integrations Status Maxtrix
 

--- a/buildsystem/detect_compiler_and_platform.cmake
+++ b/buildsystem/detect_compiler_and_platform.cmake
@@ -7,7 +7,7 @@
 # - IDLIB_CXX_COMPILER_ID_CLANG_MSVC
 #
 # If compiler detection succeeds, define IDLIB_CXX_COMPILER_ID to IDLIB_CXX_COMPILER_ID_CLANG, IDLIB_CXX_COMPILER_ID_GCC, or IDLIB_CXX_COMPILER_ID_CLANG_MSVC.
-# define IDLIX_CXX_COMPILER_NAME to IDLIB_CXX_COMPILER_ID_UNKNOWN otherwise.
+# define IDLIX_CXX_COMPILER_ID to IDLIB_CXX_COMPILER_ID_UNKNOWN otherwise.
 # Defines macro idlib_report_cxx_compiler_id to report the value of IDLIB_CXX_COMPILER_ID.
 #
 #
@@ -24,84 +24,84 @@
 # Define IDLIB_IS_MULTI_TARGET_GENERATOR to NO otherwise.
 # Define macro idlib_report_is_multi_target_generator to report the value of IDLIB_IS_MULTI_TARGET_GENERATOR.
 
-	# Compiler name detection.
+# Compiler name detection (C++).
 
-	set(IDLIB_CXX_COMPILER_ID_UNKNOWN 0)
-	set(IDLIB_CXX_COMPILER_ID_CLANG 1)
-	set(IDLIB_CXX_COMPILER_ID_MSVC 2)
-	set(IDLIB_CXX_COMPILER_ID_GCC 3)
-	
-	if (CMAKE_CXX_COMPILER MATCHES ".*clang")
-	  #message("compiler `CLANG` detected")
-	  set(IDLIB_CXX_COMPILER_ID ${IDLIB_CXX_COMPILER_ID_CLANG})
-	endif()
+set(IDLIB_CXX_COMPILER_ID_UNKNOWN 0)
+set(IDLIB_CXX_COMPILER_ID_CLANG 1)
+set(IDLIB_CXX_COMPILER_ID_MSVC 2)
+set(IDLIB_CXX_COMPILER_ID_GCC 3)
 
-	if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
-	  #message("compiler `GCC` detected")
-	  set(IDLIB_CXX_COMPILER_ID ${IDLIB_CXX_COMPILER_ID_GCC})
-	endif()
+if (CMAKE_CXX_COMPILER MATCHES ".*clang")
+  #message("compiler `CLANG` detected")
+  set(IDLIB_CXX_COMPILER_ID ${IDLIB_CXX_COMPILER_ID_CLANG})
+endif()
 
-	if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
-	  message("compiler `MSVC` detected")
-	  set(IDLIB_CXX_COMPILER_ID ${IDLIB_CXX_COMPILER_ID_MSVC})
-	endif()
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+  #message("compiler `GCC` detected")
+  set(IDLIB_CXX_COMPILER_ID ${IDLIB_CXX_COMPILER_ID_GCC})
+endif()
 
-	macro(idlib_report_cxx_compiler_id)
-	  if (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_CLANG})
-	    message("  - Idlib CXX Compiler Id: CLANG")
-	  elseif (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_GCC})
-	    message("  - Idlib CXX Compiler Id: GCC")
-	  elseif (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_MSVC})
-	    message("  - Idlib CXX Compiler Id: MSVC")
-      elseif (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_UNKNOWN})
- 	    message("  - Idlib CXX Compiler Id: Unknown")
-      else()
-	    message(FATAL_ERROR "unhandled enumeration element")
-	  endif()
-	endmacro()
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+  message("compiler `MSVC` detected")
+  set(IDLIB_CXX_COMPILER_ID ${IDLIB_CXX_COMPILER_ID_MSVC})
+endif()
 
-	# Platform name detection.
+macro(idlib_report_cxx_compiler_id)
+  if (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_CLANG})
+    message("  - Idlib CXX Compiler Id: CLANG")
+  elseif (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_GCC})
+    message("  - Idlib CXX Compiler Id: GCC")
+  elseif (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_MSVC})
+    message("  - Idlib CXX Compiler Id: MSVC")
+  elseif (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_UNKNOWN})
+    message("  - Idlib CXX Compiler Id: Unknown")
+  else()
+    message(FATAL_ERROR "unhandled enumeration element")
+  endif()
+endmacro()
 
-	set(IDLIB_PLATFORM_ID_UNKNOWN 0)
-	set(IDLIB_PLATFORM_ID_X64 1)
-	set(IDLIB_PLATFORM_ID_X86 2)
+# Platform name detection.
 
-	if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-		#message("platform `x64` detected")
-		set(IDLIB_PLATFORM_ID ${IDLIB_PLATFORM_ID_X64})
-	elseif ( CMAKE_SIZEOF_VOID_P EQUAL 4)
-		#message("platform `x86` detected" )
-		set(IDLIB_PLATFORM_ID ${IDLIB_PLATFORM_ID_X86})
-	endif()
+set(IDLIB_PLATFORM_ID_UNKNOWN 0)
+set(IDLIB_PLATFORM_ID_X64 1)
+set(IDLIB_PLATFORM_ID_X86 2)
 
-	macro(idlib_report_platform_id)
-	  if (${IDLIB_PLATFORM_ID} EQUAL ${IDLIB_PLATFORM_ID_X64})
-	    message("  - Idlib Platform Id: x64")
-	  elseif (${IDLIB_PLATFORM_ID} EQUAL ${IDLIB_PLATFORM_ID_X86})
-	    message("  - Idlib Platform Id: x86")
-	  elseif (${IDLIB_PLATFORM_ID} EQUAL ${IDLIB_PLATFORM_ID_UNKNOWN})
-	    message("  - Idlib Platform Id: Unknown")
-      else()
-	    message(FATAL_ERROR "unhandled enumeration element")
-	  endif()
-	endmacro()
-	
-	# Multi target generator detection.
+if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+    #message("platform `x64` detected")
+    set(IDLIB_PLATFORM_ID ${IDLIB_PLATFORM_ID_X64})
+elseif ( CMAKE_SIZEOF_VOID_P EQUAL 4)
+    #message("platform `x86` detected" )
+    set(IDLIB_PLATFORM_ID ${IDLIB_PLATFORM_ID_X86})
+endif()
 
-	if (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_MSVC})
-		set(IDLIB_IS_MULTI_TARGET_GENERATOR YES)
-	else()
-		set(IDLIB_IS_MULTI_TARGET_GENERATOR NO)   
-	endif()
+macro(idlib_report_platform_id)
+  if (${IDLIB_PLATFORM_ID} EQUAL ${IDLIB_PLATFORM_ID_X64})
+    message("  - Idlib Platform Id: x64")
+  elseif (${IDLIB_PLATFORM_ID} EQUAL ${IDLIB_PLATFORM_ID_X86})
+    message("  - Idlib Platform Id: x86")
+  elseif (${IDLIB_PLATFORM_ID} EQUAL ${IDLIB_PLATFORM_ID_UNKNOWN})
+    message("  - Idlib Platform Id: Unknown")
+  else()
+    message(FATAL_ERROR "unhandled enumeration element")
+  endif()
+endmacro()
 
-	macro(idlib_report_is_multi_target_generator)
-		if (IDLIB_IS_MULTI_TARGET_GENERATOR)
-		  message("  - Idlib Is Multi Target Generator: Yes")
-		else()
-		  message("  - Idlib Is Multi Target Generator: NO")
-		endif()
-	endmacro()
+# Multi target generator detection.
 
-	idlib_report_cxx_compiler_id()
-	idlib_report_platform_id()
-    idlib_report_is_multi_target_generator()
+if (${IDLIB_CXX_COMPILER_ID} EQUAL ${IDLIB_CXX_COMPILER_ID_MSVC})
+    set(IDLIB_IS_MULTI_TARGET_GENERATOR YES)
+else()
+    set(IDLIB_IS_MULTI_TARGET_GENERATOR NO)   
+endif()
+
+macro(idlib_report_is_multi_target_generator)
+    if (IDLIB_IS_MULTI_TARGET_GENERATOR)
+      message("  - Idlib Is Multi Target Generator: Yes")
+    else()
+      message("  - Idlib Is Multi Target Generator: NO")
+    endif()
+endmacro()
+
+idlib_report_cxx_compiler_id()
+idlib_report_platform_id()
+idlib_report_is_multi_target_generator()

--- a/documentation/building-under-linux-clang.md
+++ b/documentation/building-under-linux-clang.md
@@ -1,0 +1,18 @@
+# Building under Linux/Clang
+
+Ensure CMake 3.10.1 and Clang 4.0 or higher are installed.
+To compile Idlib, open a console, change to the directory in which the source of the library is located in, and enter
+```
+cmake CMakeLists.txt
+make all
+```
+CMake respects the CC and CXX upon detecting the C and C++ compiler to use.
+For building using Clang instead of GCC it might be required to prefix the above commands with
+```
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
+```
+To execute the unit tests, enter
+```
+make check
+```

--- a/documentation/building-under-linux-gcc.md
+++ b/documentation/building-under-linux-gcc.md
@@ -1,0 +1,12 @@
+# Building under Linux/GCC
+
+Ensure CMake 3.10.1 and GCC 6.4 or higher are installed.
+To compile Idlib, open a console, change to the directory in which the source of the library is located in, and enter
+```
+cmake CMakeLists.txt
+make all
+```
+To execute the unit tests, enter
+```
+make check
+```

--- a/documentation/building-under-os-x-clang.md
+++ b/documentation/building-under-os-x-clang.md
@@ -1,0 +1,12 @@
+# Building under OS X/CLANG
+
+Ensure CMake 3.10.1 and CLANG 4.0 or higher are installed.
+To compile Idlib, open a console, change to the directory in which the source of the library is located in, and enter
+```
+cmake CMakeLists.txt
+make all
+```
+To execute the unit tests, enter
+```
+make check
+```

--- a/documentation/building-under-windows-10-cygwin.md
+++ b/documentation/building-under-windows-10-cygwin.md
@@ -1,0 +1,21 @@
+# Building under Windows/Cygwin
+
+Cygwin usually ships with a very outdated version of CMake and GCC.
+However, to compile Idlib, CMake 3.10.1 or higher and GCC 6.4.0 or higher are required.
+Follow
+[this guide](building-under-windows-cygwin/how-to-install-a-more-recent-cmake-version-on-cygwin.md)
+to install/update CMake on Cygwin
+and
+[this guide](building-under-windows-cygwin/how-to-install-a-more-recent-gcc-version-on-cygwin.md)
+to install/update GCC on Cygwin.
+
+To compile Idlib, open a Cygwin console, change to the directory in which the source of the library is located in, and enter
+```
+cmake CMakeLists.txt
+make all
+```
+
+To execute the unit tests, enter
+```
+make check
+```

--- a/documentation/building-under-windows-10-cygwin/how-to-install-a-more-recent-cmake-version-on-cygwin.md
+++ b/documentation/building-under-windows-10-cygwin/how-to-install-a-more-recent-cmake-version-on-cygwin.md
@@ -1,0 +1,13 @@
+# How to install a more recent CMake version on Cygwin
+
+Cygwin usually ships with a very outdated version of CMake.
+However, to compile Idlib, CMake 3.10.1 or higher is required.
+To compile and install this  version of CMake on Cygwin, open the Cygwin terminal and enter the following commands
+```
+wget https://cmake.org/files/v3.10/cmake-3.10.1.tar.gz
+tar -xzf cmake-3.10.1.tar.gz
+cd cmake-3.10.1
+./configure --system-curl
+make all
+make install
+```

--- a/documentation/building-under-windows-10-cygwin/how-to-install-a-more-recent-gcc-version-on-cygwin.md
+++ b/documentation/building-under-windows-10-cygwin/how-to-install-a-more-recent-gcc-version-on-cygwin.md
@@ -1,0 +1,15 @@
+# How to install a more recent GCC version on Cygwin
+
+Cygwin usually ships with a very outdated version of GCC.
+However, to compile Idlib, GCC 6.4.0 or higher is required.
+To compile and install this  version of GCC on Cygwin, open the Cygwin terminal and enter the following commands
+```
+C:\cygwin64>setup-x86_64.exe -q -P wget -P gcc-g++ -P make -P diffutils -P libmpfr-devel -P libgmp-devel -P libmpc-devel
+wget http://ftp.halifax.rwth-aachen.de/gnu/gcc/gcc-6.4.0/gcc-6.4.0.tar.gz
+tar xf gcc-6.4.0.tar.gz
+mkdir build-gcc
+cd build-gcc
+../gcc-6.4.0/configure --program-suffix=-6.4.0 --enable-languages=c,c++ --disable-bootstrap --disable-shared
+make -j4
+make install
+```

--- a/documentation/building-under-windows-10-visual-studio-community-2017.md
+++ b/documentation/building-under-windows-10-visual-studio-community-2017.md
@@ -1,0 +1,16 @@
+# Building under Windows/Visual Studio Community 2017
+
+Download, install, and update Visual Studio Community 2017.
+Download and install CMake 3.10.1 or higher.
+Install Google Test Adapter for Visual Studio version 0.12.3.994 or higher is installed.
+To compile Idlib, open a Powershell console window, change to the directory in which the source of the library is located in, and enter
+```
+cmake CMakeLists.txt
+```
+CMake generates the solution file `idlib.sln` for platfom Win32. Open this file in Visual Studio.
+
+To generate the solution file idlib.sln for platform x64, enter
+```
+cmake CMakeLists.txt -DCMAKE_GENERATOR_PLATFORM=x64
+```
+instead.

--- a/idlib-math/tests/idlib/tests/math/vector/zip_max.cpp
+++ b/idlib-math/tests/idlib/tests/math/vector/zip_max.cpp
@@ -40,7 +40,7 @@ TEST(zip_max_test, vector_3i)
         auto c = idlib::zip_max(a,b);
         for (size_t i = 1, n = vector_3i::dimensionality(); i < n; ++i)
         {
-            ASSERT_TRUE(c[i] == std::min(a[i], b[i]));
+            ASSERT_TRUE(c[i] == std::max(a[i], b[i]));
         }
     }
 }


### PR DESCRIPTION
- Switch to MIT license.
- Improve documentation.
- Fix compiler detection.
- Update for latest version of Google Test.
- Fix vector zip max unit test.