### PR TITLE
Add missing 'functional' include

### DIFF
--- a/library/src/idlib/text/parser.hpp
+++ b/library/src/idlib/text/parser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 
 namespace idlib {


### PR DESCRIPTION
I tried building the project with GCC 9 and noticed the `functional` include was required.